### PR TITLE
[DO NOT MERGE, USE #29] rates fetcher interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bignumber.js": "^9.0.0",
     "bitcoinjs-lib": "^5.1.10",
     "boltz-core": "^0.4.0",
+    "decimal.js": "^10.2.1",
     "ethers": "^5.0.31",
     "is_js": "^0.9.0",
     "node-sass": "^4.14.1",

--- a/src/components/ChooseTradingPair/index.tsx
+++ b/src/components/ChooseTradingPair/index.tsx
@@ -26,6 +26,7 @@ import {
 import { timer } from 'rxjs';
 import { AmountPreview } from '../../constants/rates';
 import useExampleHook from '../../constants/ratesExampleHook';
+import Decimal from 'decimal.js';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -105,6 +106,15 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
       break;
   }
 
+
+  const amountIsPositive = (x: any): boolean => {
+    if (!Number.isNaN(x) && Number(x) > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
   const onSendAmountChange = async (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
@@ -114,10 +124,10 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     dispatch(setSendAmount(value));
 
     // preview other amount
-    const amount = Number(value);
-    if (ratesFetcher && !Number.isNaN(amount) && amount > 0) {
+    if (ratesFetcher && amountIsPositive(value)) {
       setIsPreviewing(true);
 
+      const amount = new Decimal(value);
       const receiveValue: AmountPreview = await ratesFetcher.previewGivenSend({
         amount,
         currency: sendCurrency.id,
@@ -125,7 +135,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
 
       dispatch(
         setReceiveAmount(
-          receiveValue.amountWithFees.amount.toLocaleString(undefined, {
+          receiveValue.amountWithFees.amount.toNumber().toLocaleString(undefined, {
             maximumFractionDigits: 8,
           })
         )
@@ -143,10 +153,10 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     dispatch(setReceiveAmount(value));
 
     // preview other amount
-    const amount = Number(value);
-    if (ratesFetcher && !Number.isNaN(amount) && amount > 0) {
+    if (ratesFetcher && amountIsPositive(value)) {
       setIsPreviewing(true);
 
+      const amount = new Decimal(value);
       const sendValue: AmountPreview = await ratesFetcher.previewGivenReceive({
         amount,
         currency: receiveCurrency.id,
@@ -154,7 +164,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
 
       dispatch(
         setSendAmount(
-          sendValue.amountWithFees.amount.toLocaleString(undefined, {
+          sendValue.amountWithFees.amount.toNumber().toLocaleString(undefined, {
             maximumFractionDigits: 8,
           })
         )

--- a/src/components/ChooseTradingPair/index.tsx
+++ b/src/components/ChooseTradingPair/index.tsx
@@ -1,6 +1,6 @@
 import { Grid, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import AssetSelector from '../AssetSelector';
 import Button from '../Button';
 import CardComponent from '../Card';
@@ -24,8 +24,8 @@ import {
   setSwapStep,
 } from '../../store/swaps-slice';
 import { timer } from 'rxjs';
-import { AmountPreview, RatesFetcher } from '../../constants/rates';
-import ExampleFetcherWithInitalizer from '../../constants/rates_example';
+import { AmountPreview } from '../../constants/rates';
+import useExampleHook from '../../constants/ratesExampleHook';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -75,7 +75,6 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
   const swapProvider = useAppSelector(selectSwapProvider);
   const ratesLoaded = useAppSelector(isRatesLoaded);
 
-  const [tdexFetcher, setTdexFetcher] = useState<RatesFetcher | undefined>();
   const [isPreviewing, setIsPreviewing] = useState(false);
 
   const sendCurrency = CurrencyOptions.find(
@@ -92,29 +91,8 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     Number(receiveAmount) === 0 ||
     !swapProvider;
 
-  useEffect(() => {
-    (async () => {
-      // start a new Example rates fetcher
-      // This is an example of stateful implementation with async
-      // instantiation using the The Functional Options Pattern
-      // https://betterprogramming.pub/how-to-write-an-async-class-constructor-in-typescript-javascript-7d7e8325c35e
 
-      const tdexFetcher = new ExampleFetcherWithInitalizer(
-        await ExampleFetcherWithInitalizer.WithoutInterval()
-      );
-      setTdexFetcher(tdexFetcher);
-
-      // here we should instantiate all other fetchers
-      // const comitFetcher = ...
-      // const boltzFetcher = ...
-
-      //Clean up
-      return () => {
-        tdexFetcher.Clean();
-        // we should clean the other fetchers as well
-      };
-    })();
-  }, []);
+  const tdexFetcher = useExampleHook();
 
   let ratesFetcher;
   switch (swapProvider) {
@@ -140,7 +118,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     if (ratesFetcher && !Number.isNaN(amount) && amount > 0) {
       setIsPreviewing(true);
 
-      const receiveValue: AmountPreview = await ratesFetcher.PreviewGivenSend({
+      const receiveValue: AmountPreview = await ratesFetcher.previewGivenSend({
         amount,
         currency: sendCurrency.id,
       });
@@ -169,7 +147,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     if (ratesFetcher && !Number.isNaN(amount) && amount > 0) {
       setIsPreviewing(true);
 
-      const sendValue: AmountPreview = await ratesFetcher.PreviewGivenReceive({
+      const sendValue: AmountPreview = await ratesFetcher.previewGivenReceive({
         amount,
         currency: receiveCurrency.id,
       });

--- a/src/components/ChooseTradingPair/index.tsx
+++ b/src/components/ChooseTradingPair/index.tsx
@@ -140,7 +140,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
     if (ratesFetcher && !Number.isNaN(amount) && amount > 0) {
       setIsPreviewing(true);
 
-      const receiveValue = await ratesFetcher.PreviewGivenSend({
+      const receiveValue: AmountPreview = await ratesFetcher.PreviewGivenSend({
         amount,
         currency: sendCurrency.id,
       });

--- a/src/components/ChooseTradingPair/index.tsx
+++ b/src/components/ChooseTradingPair/index.tsx
@@ -24,7 +24,7 @@ import {
   setSwapStep,
 } from '../../store/swaps-slice';
 import { timer } from 'rxjs';
-import { AmountPreview } from '../../constants/rates';
+import { AmountPreview, RatesFetcher } from '../../constants/rates';
 import useExampleHook from '../../constants/ratesExampleHook';
 import Decimal from 'decimal.js';
 
@@ -95,7 +95,7 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
 
   const tdexFetcher = useExampleHook();
 
-  let ratesFetcher;
+  let ratesFetcher: RatesFetcher | null;
   switch (swapProvider) {
     case SwapProvider.TDEX:
       ratesFetcher = tdexFetcher;
@@ -131,7 +131,12 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
       const receiveValue: AmountPreview = await ratesFetcher.previewGivenSend({
         amount,
         currency: sendCurrency.id,
-      });
+      },
+        [
+          sendCurrency.id,
+          receiveCurrency.id
+        ]
+      );
 
       dispatch(
         setReceiveAmount(
@@ -160,7 +165,12 @@ const ChooseTradingPair = (_props: ChooseTradingPairProps) => {
       const sendValue: AmountPreview = await ratesFetcher.previewGivenReceive({
         amount,
         currency: receiveCurrency.id,
-      });
+      },
+        [
+          sendCurrency.id,
+          receiveCurrency.id
+        ]
+      );
 
       dispatch(
         setSendAmount(

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -1,5 +1,11 @@
 import CurrencyID from './currency';
 
+
+export enum AmountFeeType {
+  Percentage = 'Percentage',
+  Fixed = 'Fixed',
+  // TODO add more types here for all providers
+}
 export interface AmountCurrency {
   amount: number;
   currency: CurrencyID;
@@ -10,7 +16,7 @@ export interface AmountPreview {
   amountWithFees: AmountCurrency;
   // This is general purpose key value object that can be used to communicate
   // to end users the detail of amounts added into the amountWithFees
-  feesDetail?: Record<string, any>;
+  feesDetail?: Record<AmountFeeType, number>;
 }
 
 export interface RatesFetcherOpts { }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -6,7 +6,7 @@ export interface AmountCurrency {
 }
 
 export interface AmountPreview {
-  //This is comprhensive of swap provider fees
+  // This is comprehensive of swap provider fees
   amountWithFees: AmountCurrency;
   // This is general purpose key value object that can be used to communicate
   // to end users the detail of amounts added into the amountWithFees

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -32,4 +32,7 @@ export interface RatesFetcher {
   PreviewGivenReceive(
     amountWithCurrency: AmountCurrency
   ): Promise<AmountPreview>;
+
+  // Any complex instatiation or tickers could be cleaned up
+  Clean(): void;
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -7,14 +7,14 @@ export enum AmountFeeType {
   Fixed = 'Fixed',
   // TODO add more types here for all providers
 }
-export interface AmountCurrency {
+export interface CurrencyAmount {
   amount: Decimal;
   currency: CurrencyID;
 }
 
 export interface AmountPreview {
   // This is comprehensive of swap provider fees
-  amountWithFees: AmountCurrency;
+  amountWithFees: CurrencyAmount;
   // This is general purpose key value object that can be used to communicate
   // to end users the detail of amounts added into the amountWithFees
   feesDetail?: Record<AmountFeeType, number>;
@@ -28,16 +28,16 @@ export interface RatesFetcher {
   // By default it "should" expect the "sending amount" to be given, but also the "receiving amount" could be
   // passed setting the isSend parameter to false in order to do a reverse calculation.
   preview(
-    amountWithCurrency: AmountCurrency,
+    amountWithCurrency: CurrencyAmount,
     isSend: boolean
   ): Promise<AmountPreview>;
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  previewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
+  previewGivenSend(amountWithCurrency: CurrencyAmount): Promise<AmountPreview>;
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
   previewGivenReceive(
-    amountWithCurrency: AmountCurrency
+    amountWithCurrency: CurrencyAmount
   ): Promise<AmountPreview>;
 
   // define wich trading pair is suppported by the fetcher implementation

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -5,7 +5,7 @@ export interface AmountCurrency {
   currency: CurrencyID;
 }
 
-export interface Preview {
+export interface AmountPreview {
   //This is comprhensive of swap provider fees
   amountWithFees: AmountCurrency;
   // This is general purpose key value object that can be used to communicate
@@ -21,11 +21,11 @@ export interface RatesFetcher {
   Preview(
     amountWithCurrency: AmountCurrency,
     isSend: boolean
-  ): Promise<Preview>;
+  ): Promise<AmountPreview>;
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<Preview>;
+  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<Preview>;
+  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import CurrencyID from './currency';
 
 
@@ -7,7 +8,7 @@ export enum AmountFeeType {
   // TODO add more types here for all providers
 }
 export interface AmountCurrency {
-  amount: number;
+  amount: Decimal;
   currency: CurrencyID;
 }
 

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -26,23 +26,20 @@ export interface RatesFetcher {
   // amount to be sent or to be received of the opposite currency in the pair, comprehensive of fees.
   // By default it "should" expect the "sending amount" to be given, but also the "receiving amount" could be
   // passed setting the isSend parameter to false in order to do a reverse calculation.
-  Preview(
+  preview(
     amountWithCurrency: AmountCurrency,
     isSend: boolean
   ): Promise<AmountPreview>;
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
+  previewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(
+  previewGivenReceive(
     amountWithCurrency: AmountCurrency
   ): Promise<AmountPreview>;
 
-  // Any complex instatiation or tickers could be cleaned up
-  Clean(): void;
-
   // define wich trading pair is suppported by the fetcher implementation
-  IsPairSupported(x: CurrencyID, y: CurrencyID): boolean;
+  isPairSupported(x: CurrencyID, y: CurrencyID): boolean;
 
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -15,7 +15,7 @@ export interface AmountPreview {
 
 export interface RatesFetcher {
   // Preview wants the amount and the currency entered by the user and will return the
-  // amount to be sent or to be received of the opposite currency in the pair, comprhensive of fees.
+  // amount to be sent or to be received of the opposite currency in the pair, comprehensive of fees.
   // By default it "should" expect the "sending amount" to be given, but also the "receiving amount" could be
   // passed setting the isSend parameter to false in order to do a reverse calculation.
   Preview(

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -13,8 +13,10 @@ export interface AmountPreview {
   feesDetail?: Record<string, any>;
 }
 
+export interface RatesFetcherOpts {}
+
 export interface RatesFetcher {
-  // Preview wants the amount and the currency entered by the user and will return the
+  // preview wants the amount and the currency entered by the user and will return the
   // amount to be sent or to be received of the opposite currency in the pair, comprehensive of fees.
   // By default it "should" expect the "sending amount" to be given, but also the "receiving amount" could be
   // passed setting the isSend parameter to false in order to do a reverse calculation.
@@ -27,5 +29,7 @@ export interface RatesFetcher {
   PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<AmountPreview>;
+  PreviewGivenReceive(
+    amountWithCurrency: AmountCurrency
+  ): Promise<AmountPreview>;
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -13,7 +13,7 @@ export interface AmountPreview {
   feesDetail?: Record<string, any>;
 }
 
-export interface RatesFetcherOpts {}
+export interface RatesFetcherOpts { }
 
 export interface RatesFetcher {
   // preview wants the amount and the currency entered by the user and will return the
@@ -35,4 +35,8 @@ export interface RatesFetcher {
 
   // Any complex instatiation or tickers could be cleaned up
   Clean(): void;
+
+  // define wich trading pair is suppported by the fetcher implementation
+  IsPairSupported(x: CurrencyID, y: CurrencyID): boolean;
+
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -7,6 +7,9 @@ export enum AmountFeeType {
   Fixed = 'Fixed',
   // TODO add more types here for all providers
 }
+
+export type CurrencyPair = [CurrencyID, CurrencyID];
+
 export interface CurrencyAmount {
   amount: Decimal;
   currency: CurrencyID;
@@ -29,18 +32,22 @@ export interface RatesFetcher {
   // passed setting the isSend parameter to false in order to do a reverse calculation.
   preview(
     amountWithCurrency: CurrencyAmount,
+    pair: CurrencyPair,
     isSend: boolean
   ): Promise<AmountPreview>;
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  previewGivenSend(amountWithCurrency: CurrencyAmount): Promise<AmountPreview>;
+  previewGivenSend(
+    amountWithCurrency: CurrencyAmount,
+    pair: CurrencyPair
+  ): Promise<AmountPreview>;
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
   previewGivenReceive(
-    amountWithCurrency: CurrencyAmount
+    amountWithCurrency: CurrencyAmount,
+    pair: CurrencyPair,
   ): Promise<AmountPreview>;
 
   // define wich trading pair is suppported by the fetcher implementation
-  isPairSupported(x: CurrencyID, y: CurrencyID): boolean;
-
+  isPairSupported(pair: CurrencyPair): boolean;
 }

--- a/src/constants/rates.ts
+++ b/src/constants/rates.ts
@@ -1,0 +1,31 @@
+import CurrencyID from './currency';
+
+export interface AmountCurrency {
+  amount: number;
+  currency: CurrencyID;
+}
+
+export interface Preview {
+  //This is comprhensive of swap provider fees
+  amountWithFees: AmountCurrency;
+  // This is general purpose key value object that can be used to communicate
+  // to end users the detail of amounts added into the amountWithFees
+  feesDetail?: Record<string, any>;
+}
+
+export interface RatesFetcher {
+  // Preview wants the amount and the currency entered by the user and will return the
+  // amount to be sent or to be received of the opposite currency in the pair, comprhensive of fees.
+  // By default it "should" expect the "sending amount" to be given, but also the "receiving amount" could be
+  // passed setting the isSend parameter to false in order to do a reverse calculation.
+  Preview(
+    amountWithCurrency: AmountCurrency,
+    isSend: boolean
+  ): Promise<Preview>;
+
+  // PreviewGivenSend does the same thing as Preview with isSend = true
+  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<Preview>;
+
+  // PreviewGivenReceive does the same thing as Preview with isSend = false
+  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<Preview>;
+}

--- a/src/constants/ratesExample.ts
+++ b/src/constants/ratesExample.ts
@@ -5,6 +5,7 @@ import {
   AmountPreview,
   CurrencyAmount,
   RatesFetcherOpts,
+  CurrencyPair,
 } from './rates';
 
 interface ExampleOptions extends RatesFetcherOpts {
@@ -43,28 +44,35 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
     }
   }
 
-  isPairSupported(x: CurrencyID, y: CurrencyID): boolean {
-    const pair = [x, y];
+  isPairSupported(pair: CurrencyPair): boolean {
     return pair.includes(CurrencyID.LIQUID_BTC) && pair.includes(CurrencyID.LIQUID_USDT);
   }
 
   preview(
     amountWithCurrency: CurrencyAmount,
+    pair: CurrencyPair,
     isSend: boolean = true
   ): Promise<AmountPreview> {
-    return this._preview(amountWithCurrency, isSend);
+    if (!this.isPairSupported(pair)) throw new Error('pair is not support');
+
+    return this.previewBTCUSDT(amountWithCurrency, isSend);
   }
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  previewGivenSend(amountWithCurrency: CurrencyAmount): Promise<AmountPreview> {
-    return this._preview(amountWithCurrency, true);
+  previewGivenSend(amountWithCurrency: CurrencyAmount, pair: CurrencyPair): Promise<AmountPreview> {
+    if (!this.isPairSupported(pair)) throw new Error('pair is not support');
+
+    return this.previewBTCUSDT(amountWithCurrency, true);
   }
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
   previewGivenReceive(
-    amountWithCurrency: CurrencyAmount
+    amountWithCurrency: CurrencyAmount,
+    pair: CurrencyPair
   ): Promise<AmountPreview> {
-    return this._preview(amountWithCurrency, false);
+    if (!this.isPairSupported(pair)) throw new Error('pair is not support');
+
+    return this.previewBTCUSDT(amountWithCurrency, false);
   }
 
   private async _fetchPriceBTC(): Promise<Decimal> {
@@ -74,7 +82,7 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
     return new Decimal(json.bitcoin.usd as number);
   }
 
-  private async _preview(
+  private async previewBTCUSDT(
     amountWithCurrency: CurrencyAmount,
     isSend: boolean = true
   ): Promise<AmountPreview> {

--- a/src/constants/ratesExample.ts
+++ b/src/constants/ratesExample.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js'
 import CurrencyID from './currency';
 import {
   RatesFetcher,
@@ -15,7 +16,7 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
   private url: string;
   private useInterval: boolean;
   private interval: any;
-  private usdPerBtc: number = 0;
+  private usdPerBtc: Decimal = new Decimal(0);
   private isFetching: boolean = false;
 
   constructor(options: ExampleOptions) {
@@ -66,11 +67,11 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
     return this._preview(amountWithCurrency, false);
   }
 
-  private async _fetchPriceBTC(): Promise<number> {
+  private async _fetchPriceBTC(): Promise<Decimal> {
     const res = await fetch(this.url);
     const json = await res.json();
 
-    return json.bitcoin.usd as number;
+    return new Decimal(json.bitcoin.usd as number);
   }
 
   private async _preview(
@@ -85,9 +86,10 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
       (isSend && amountWithCurrency.currency === CurrencyID.LIQUID_BTC) ||
       (!isSend && amountWithCurrency.currency !== CurrencyID.LIQUID_USDT);
 
+    console.log(amountWithCurrency.amount.toString())
     const amount = isBTCcomingIn
-      ? usdPerBtc * amountWithCurrency.amount
-      : amountWithCurrency.amount / usdPerBtc;
+      ? usdPerBtc.mul(amountWithCurrency.amount)
+      : amountWithCurrency.amount.div(usdPerBtc);
     const currency = isBTCcomingIn
       ? CurrencyID.LIQUID_USDT
       : CurrencyID.LIQUID_BTC;

--- a/src/constants/ratesExample.ts
+++ b/src/constants/ratesExample.ts
@@ -35,18 +35,19 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
     }
   }
 
-  Clean(): void {
+
+  clean(): void {
     if (this.useInterval && this.interval) {
       clearInterval(this.interval);
     }
   }
 
-  IsPairSupported(x: CurrencyID, y: CurrencyID): boolean {
+  isPairSupported(x: CurrencyID, y: CurrencyID): boolean {
     const pair = [x, y];
     return pair.includes(CurrencyID.LIQUID_BTC) && pair.includes(CurrencyID.LIQUID_USDT);
   }
 
-  async Preview(
+  preview(
     amountWithCurrency: AmountCurrency,
     isSend: boolean = true
   ): Promise<AmountPreview> {
@@ -54,12 +55,12 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
   }
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
+  previewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
     return this._preview(amountWithCurrency, true);
   }
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(
+  previewGivenReceive(
     amountWithCurrency: AmountCurrency
   ): Promise<AmountPreview> {
     return this._preview(amountWithCurrency, false);

--- a/src/constants/ratesExample.ts
+++ b/src/constants/ratesExample.ts
@@ -3,7 +3,7 @@ import CurrencyID from './currency';
 import {
   RatesFetcher,
   AmountPreview,
-  AmountCurrency,
+  CurrencyAmount,
   RatesFetcherOpts,
 } from './rates';
 
@@ -49,20 +49,20 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
   }
 
   preview(
-    amountWithCurrency: AmountCurrency,
+    amountWithCurrency: CurrencyAmount,
     isSend: boolean = true
   ): Promise<AmountPreview> {
     return this._preview(amountWithCurrency, isSend);
   }
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  previewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
+  previewGivenSend(amountWithCurrency: CurrencyAmount): Promise<AmountPreview> {
     return this._preview(amountWithCurrency, true);
   }
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
   previewGivenReceive(
-    amountWithCurrency: AmountCurrency
+    amountWithCurrency: CurrencyAmount
   ): Promise<AmountPreview> {
     return this._preview(amountWithCurrency, false);
   }
@@ -75,7 +75,7 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
   }
 
   private async _preview(
-    amountWithCurrency: AmountCurrency,
+    amountWithCurrency: CurrencyAmount,
     isSend: boolean = true
   ): Promise<AmountPreview> {
     const usdPerBtc = this.useInterval

--- a/src/constants/ratesExampleHook.ts
+++ b/src/constants/ratesExampleHook.ts
@@ -1,0 +1,38 @@
+
+import { useState, useEffect } from 'react';
+import { RatesFetcher } from './rates';
+import ExampleFetcherWithInitalizer from './ratesExample';
+
+export default function useExampleHook(): RatesFetcher | null {
+  let [
+    fetcher,
+    setFetcher,
+  ] = useState<RatesFetcher | null>(null);
+
+
+  useEffect(() => {
+    (async () => {
+      // start a new Example rates fetcher
+      // This is an example of stateful implementation with async
+      // instantiation using the The Functional Options Pattern
+      // https://betterprogramming.pub/how-to-write-an-async-class-constructor-in-typescript-javascript-7d7e8325c35e
+
+      const tdexFetcher = new ExampleFetcherWithInitalizer(
+        await ExampleFetcherWithInitalizer.WithoutInterval()
+      );
+      setFetcher(tdexFetcher);
+
+      // here we should instantiate all other fetchers
+      // const comitFetcher = ...
+      // const boltzFetcher = ...
+
+      //Clean up
+      return () => {
+        tdexFetcher.clean();
+        // we should clean the other fetchers as well
+      };
+    })();
+  }, []);
+
+  return fetcher;
+}

--- a/src/constants/rates_example.ts
+++ b/src/constants/rates_example.ts
@@ -41,6 +41,11 @@ export default class ExampleFetcherWithInitalizer implements RatesFetcher {
     }
   }
 
+  IsPairSupported(x: CurrencyID, y: CurrencyID): boolean {
+    const pair = [x, y];
+    return pair.includes(CurrencyID.LIQUID_BTC) && pair.includes(CurrencyID.LIQUID_USDT);
+  }
+
   async Preview(
     amountWithCurrency: AmountCurrency,
     isSend: boolean = true

--- a/src/constants/rates_example.ts
+++ b/src/constants/rates_example.ts
@@ -1,0 +1,53 @@
+import CurrencyID from './currency';
+import { RatesFetcher, Preview, AmountCurrency } from './rates';
+
+export default class ExampleFetcher implements RatesFetcher {
+  private client: any;
+
+  constructor() {
+    this.client = window.fetch;
+  }
+
+  async Preview(
+    amountWithCurrency: AmountCurrency,
+    isSend: boolean = true
+  ): Promise<Preview> {
+    const usdPerBtc = await this.fetchPriceBTC();
+
+    const isBTCcomingIn =
+      (isSend && amountWithCurrency.currency === CurrencyID.LIQUID_BTC) ||
+      (!isSend && amountWithCurrency.currency === CurrencyID.LIQUID_USDT);
+
+    const amount = isBTCcomingIn
+      ? usdPerBtc * amountWithCurrency.amount
+      : amountWithCurrency.amount / usdPerBtc;
+    const currency = isBTCcomingIn
+      ? CurrencyID.LIQUID_USDT
+      : CurrencyID.LIQUID_BTC;
+    return {
+      amountWithFees: {
+        amount: amount,
+        currency: currency,
+      },
+    };
+  }
+
+  // PreviewGivenSend does the same thing as Preview with isSend = true
+  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<Preview> {
+    return this.Preview(amountWithCurrency, true);
+  }
+
+  // PreviewGivenReceive does the same thing as Preview with isSend = false
+  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<Preview> {
+    return this.Preview(amountWithCurrency, false);
+  }
+
+  async fetchPriceBTC(): Promise<number> {
+    const res = await this.client(
+      'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'
+    );
+    const json = await res.json();
+
+    return json.bitcoin.usd as number;
+  }
+}

--- a/src/constants/rates_example.ts
+++ b/src/constants/rates_example.ts
@@ -1,5 +1,5 @@
 import CurrencyID from './currency';
-import { RatesFetcher, Preview, AmountCurrency } from './rates';
+import { RatesFetcher, AmountPreview, AmountCurrency } from './rates';
 
 export default class ExampleFetcher implements RatesFetcher {
   private client: any;
@@ -11,7 +11,7 @@ export default class ExampleFetcher implements RatesFetcher {
   async Preview(
     amountWithCurrency: AmountCurrency,
     isSend: boolean = true
-  ): Promise<Preview> {
+  ): Promise<AmountPreview> {
     const usdPerBtc = await this.fetchPriceBTC();
 
     const isBTCcomingIn =
@@ -33,12 +33,12 @@ export default class ExampleFetcher implements RatesFetcher {
   }
 
   // PreviewGivenSend does the same thing as Preview with isSend = true
-  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<Preview> {
+  PreviewGivenSend(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
     return this.Preview(amountWithCurrency, true);
   }
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<Preview> {
+  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
     return this.Preview(amountWithCurrency, false);
   }
 

--- a/src/constants/rates_example.ts
+++ b/src/constants/rates_example.ts
@@ -1,11 +1,22 @@
 import CurrencyID from './currency';
-import { RatesFetcher, AmountPreview, AmountCurrency } from './rates';
+import {
+  RatesFetcher,
+  AmountPreview,
+  AmountCurrency,
+  RatesFetcherOpts,
+} from './rates';
 
-export default class ExampleFetcher implements RatesFetcher {
-  private client: any;
+interface ExampleOptions extends RatesFetcherOpts {
+  url: string;
+}
 
-  constructor() {
-    this.client = window.fetch;
+//'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'
+
+export default class ExampleFetcherWithInitalizer implements RatesFetcher {
+  private url: string;
+
+  constructor(options: ExampleOptions) {
+    this.url = options.url;
   }
 
   async Preview(
@@ -38,16 +49,23 @@ export default class ExampleFetcher implements RatesFetcher {
   }
 
   // PreviewGivenReceive does the same thing as Preview with isSend = false
-  PreviewGivenReceive(amountWithCurrency: AmountCurrency): Promise<AmountPreview> {
+  PreviewGivenReceive(
+    amountWithCurrency: AmountCurrency
+  ): Promise<AmountPreview> {
     return this.Preview(amountWithCurrency, false);
   }
 
   async fetchPriceBTC(): Promise<number> {
-    const res = await this.client(
-      'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'
-    );
+    const res = await fetch(this.url);
     const json = await res.json();
 
     return json.bitcoin.usd as number;
+  }
+
+  public static async WithCustomInitializer(): Promise<ExampleOptions> {
+    return {
+      url:
+        'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd',
+    };
   }
 }

--- a/src/constants/rates_example.ts
+++ b/src/constants/rates_example.ts
@@ -16,7 +16,7 @@ export default class ExampleFetcher implements RatesFetcher {
 
     const isBTCcomingIn =
       (isSend && amountWithCurrency.currency === CurrencyID.LIQUID_BTC) ||
-      (!isSend && amountWithCurrency.currency === CurrencyID.LIQUID_USDT);
+      (!isSend && amountWithCurrency.currency !== CurrencyID.LIQUID_USDT);
 
     const amount = isBTCcomingIn
       ? usdPerBtc * amountWithCurrency.amount

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
@@ -19,5 +23,7 @@
     "jsx": "react",
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
This commits adds an idea of what could look like an abstract interface where the UI components (ie. ChooseTradingPair) could depend upon it.

Each Swap provider will implement in the most sensible and specific way, in the end the UI will need to convert from Amount A to Amount B, based on what the user is entering.

The idea is to have one main method, which I called here `Preview`, that will calculate the "opposite" amount using the rates of the provider to make the conversion and the final calculation to pre-fill the other input. The second parameter is the boolean `isSend` which could be helpful for implementing the "what I need to send to receive X of this coin"
I added also `PreviewGivenSend` and `PreviewGivenReceive`, which are single parameter version of `Preview`. They are redundant, but just left there as alternative in case the isSend boolean in Preview is not enough self-documenting.



The reason I didn't exposed a simple method that returns the rates/price is that it will uplift underlying implementation details of specific swap providers in the UI, which should be abstracted away if possible.



BONUS: I added a `ExampleFetcher` that is a dumb CoinGecko wrapper that shows how it could be implemented. IMO should not be merged, just there as showcase.



## TODOs

- [x] Refactor ChooseTradingPair to trigger the Preview method `onAmountChange` and `onAssetChange` binding specific implementation to currency pairs




Please @opendexnetwork/opendex-app review
﻿
