### PR TITLE
Unidirectional pair support

### DIFF
--- a/src/__tests__/utils/swapProvider.spec.ts
+++ b/src/__tests__/utils/swapProvider.spec.ts
@@ -10,9 +10,6 @@ describe('getSwapProvider', () => {
     expect(getSwapProvider(Currency.LIQUID_USDT, Currency.LIQUID_BTC)).toEqual(
       SwapProvider.TDEX
     );
-    expect(getSwapProvider(Currency.MONERO, Currency.BTC)).toEqual(
-      SwapProvider.COMIT
-    );
     expect(getSwapProvider(Currency.BTC, Currency.MONERO)).toEqual(
       SwapProvider.COMIT
     );
@@ -36,5 +33,6 @@ describe('getSwapProvider', () => {
       undefined
     );
     expect(getSwapProvider(Currency.LTC, Currency.BTC)).toEqual(undefined);
+    expect(getSwapProvider(Currency.MONERO, Currency.BTC)).toEqual(undefined);
   });
 });

--- a/src/constants/swap.ts
+++ b/src/constants/swap.ts
@@ -1,4 +1,5 @@
 import { CurrencyID } from './currency';
+import { CurrencyPair } from './rates';
 
 export enum SwapProvider {
   BOLTZ = 'Boltz',
@@ -6,17 +7,33 @@ export enum SwapProvider {
   TDEX = 'TDex',
 }
 
+export enum Direction {
+  SINGLE,
+  BOTH,
+}
+
+export class SwapProviderPair {
+  public constructor(
+    public pair: CurrencyPair,
+    public direction: Direction = Direction.BOTH
+  ) {}
+}
+
 export const swapProviders = {
   [SwapProvider.BOLTZ]: [
-    [CurrencyID.BTC, CurrencyID.LIGHTNING_BTC],
-    [CurrencyID.BTC, CurrencyID.LIGHTNING_LTC],
-    [CurrencyID.ETH, CurrencyID.LIGHTNING_BTC],
-    [CurrencyID.ETH_USDT, CurrencyID.LIGHTNING_BTC],
-    [CurrencyID.LTC, CurrencyID.LIGHTNING_BTC],
-    [CurrencyID.LTC, CurrencyID.LIGHTNING_LTC],
+    new SwapProviderPair([CurrencyID.BTC, CurrencyID.LIGHTNING_BTC]),
+    new SwapProviderPair([CurrencyID.BTC, CurrencyID.LIGHTNING_LTC]),
+    new SwapProviderPair([CurrencyID.ETH, CurrencyID.LIGHTNING_BTC]),
+    new SwapProviderPair([CurrencyID.ETH_USDT, CurrencyID.LIGHTNING_BTC]),
+    new SwapProviderPair([CurrencyID.LTC, CurrencyID.LIGHTNING_BTC]),
+    new SwapProviderPair([CurrencyID.LTC, CurrencyID.LIGHTNING_LTC]),
   ],
-  [SwapProvider.COMIT]: [[CurrencyID.BTC, CurrencyID.MONERO]],
-  [SwapProvider.TDEX]: [[CurrencyID.LIQUID_BTC, CurrencyID.LIQUID_USDT]],
+  [SwapProvider.COMIT]: [
+    new SwapProviderPair([CurrencyID.BTC, CurrencyID.MONERO], Direction.SINGLE),
+  ],
+  [SwapProvider.TDEX]: [
+    new SwapProviderPair([CurrencyID.LIQUID_BTC, CurrencyID.LIQUID_USDT]),
+  ],
 };
 
 export enum SwapStep {

--- a/src/utils/swapProvider.ts
+++ b/src/utils/swapProvider.ts
@@ -1,4 +1,4 @@
-import { SwapProvider, swapProviders } from '../constants/swap';
+import { Direction, SwapProvider, swapProviders } from '../constants/swap';
 import Currency from '../constants/currency';
 
 export const getSwapProvider = (
@@ -8,10 +8,15 @@ export const getSwapProvider = (
   for (const [key, value] of Object.entries(swapProviders)) {
     if (
       value.some(
-        pair =>
-          pair.includes(sendAsset) &&
-          pair.includes(receiveAsset) &&
-          (sendAsset !== receiveAsset || pair[0] === pair[1])
+        provider_pair =>
+          ((provider_pair.direction === Direction.BOTH &&
+            provider_pair.pair.includes(sendAsset) &&
+            provider_pair.pair.includes(receiveAsset)) ||
+            (provider_pair.direction === Direction.SINGLE &&
+              provider_pair.pair[0] === sendAsset &&
+              provider_pair.pair[1] === receiveAsset)) &&
+          (sendAsset !== receiveAsset ||
+            provider_pair.pair[0] === provider_pair.pair[1])
       )
     ) {
       return key as SwapProvider;


### PR DESCRIPTION
At the moment COMIT can only support buying Monero.
This is due to the nature of the XMR<>BTC protocol - where Bitcoin has to lock first, which means the service provider should never be on the Bitcoin lock side.
The previous swap-provider and currency pair relation only allowed supporting the currency pair fully (i.e. in both directions) or not.
With this change we can now depict supporting only one direction for a currency pair.
I tried to keep it simple to extend adding pair support for other providers and default to support both directions.