### PR TITLE
feat(boltz): add btc reverse swap flow

### DIFF
--- a/src/components/BoltzSwapFlow/components/BoltzRefundStatus/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzRefundStatus/index.tsx
@@ -11,7 +11,7 @@ import {
   SwapUpdateEvent,
 } from '../../../../constants/boltzSwap';
 import { useBoltzConfiguration } from '../../../../context/NetworkContext';
-import BoltzStatus from '../BoltzStatus';
+import BoltzSubmarineStatus from '../BoltzSubmarineStatus';
 
 type BoltzRefundStatusProps = {
   refundDetails: RefundDetails;
@@ -92,7 +92,7 @@ const BoltzRefundStatus = (props: BoltzRefundStatusProps): ReactElement => {
 
   return (
     <>
-      <BoltzStatus swapStatus={swapStatus!} />
+      <BoltzSubmarineStatus swapStatus={swapStatus!} />
       {!!swapTransaction?.transactionHex &&
         !swapSteps.some(step => step.status.includes(swapStatus.status)) && (
           <TextField

--- a/src/components/BoltzSwapFlow/components/BoltzReverseDestination/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseDestination/index.tsx
@@ -65,11 +65,8 @@ const BoltzReverseDestination = (
 ): ReactElement => {
   const { proceedToNext } = props;
   const classes = useStyles();
-  const {
-    apiEndpoint,
-    bitcoinConstants,
-    litecoinConstants,
-  } = useBoltzConfiguration();
+  const { apiEndpoint, bitcoinConstants, litecoinConstants } =
+    useBoltzConfiguration();
   const receiveCurrency = useAppSelector(selectReceiveAsset);
   const sendAmount = useAppSelector(selectSendAmount);
   const sendCurrency = useAppSelector(selectSendAsset);

--- a/src/components/BoltzSwapFlow/components/BoltzReverseDestination/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseDestination/index.tsx
@@ -1,0 +1,209 @@
+import {
+  createStyles,
+  FormControlLabel,
+  Grid,
+  makeStyles,
+  Switch,
+  TextField,
+  Tooltip,
+} from '@material-ui/core';
+import BigNumber from 'bignumber.js';
+import { crypto } from 'bitcoinjs-lib';
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import { BOLTZ_CREATE_SWAP_API_URL } from '../../../../api/boltzApiUrls';
+import { boltzPairsMap } from '../../../../constants/boltzRates';
+import {
+  BoltzSwapResponse,
+  ClaimDetails,
+} from '../../../../constants/boltzSwap';
+import { useBoltzConfiguration } from '../../../../context/NetworkContext';
+import { isAddressValid } from '../../../../services/reverse/addressValidation';
+import {
+  generateKeys,
+  getHexString,
+} from '../../../../services/submarine/keys';
+import { randomBytes } from '../../../../services/submarine/randomBytes';
+import { useAppSelector } from '../../../../store/hooks';
+import {
+  selectReceiveAsset,
+  selectSendAmount,
+  selectSendAsset,
+} from '../../../../store/swaps-slice';
+import svgIcons from '../../../../utils/svgIcons';
+
+import BoltzSwapStep from '../BoltzSwapStep';
+
+type BoltzReverseDestinationProps = {
+  proceedToNext: (
+    swapDetails: BoltzSwapResponse,
+    claimDetails: ClaimDetails
+  ) => void;
+};
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    input: {
+      borderRadius: 0,
+      alignItems: 'start',
+    },
+    instant: {
+      marginTop: '1rem',
+      '& .MuiFormControlLabel-label': {
+        display: 'flex',
+        alignItems: 'center',
+      },
+    },
+    instantHint: {
+      height: '1.25rem',
+      marginLeft: '0.5rem',
+    },
+  })
+);
+
+const BoltzReverseDestination = (
+  props: BoltzReverseDestinationProps
+): ReactElement => {
+  const { proceedToNext } = props;
+  const classes = useStyles();
+  const {
+    apiEndpoint,
+    bitcoinConstants,
+    litecoinConstants,
+  } = useBoltzConfiguration();
+  const receiveCurrency = useAppSelector(selectReceiveAsset);
+  const sendAmount = useAppSelector(selectSendAmount);
+  const sendCurrency = useAppSelector(selectSendAsset);
+  const [address, setAddrerss] = useState('');
+  const [instant, setInstant] = useState(true);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [keys, setKeys] = useState<{ publicKey?: string; privateKey?: string }>(
+    {}
+  );
+  const network = useMemo(
+    () =>
+      boltzPairsMap(receiveCurrency) === 'BTC'
+        ? bitcoinConstants
+        : litecoinConstants,
+    [bitcoinConstants, litecoinConstants, receiveCurrency]
+  );
+
+  const placeholder = `${receiveCurrency} receiving address`;
+
+  useEffect(() => {
+    setKeys(generateKeys(network));
+  }, [network]);
+
+  const createSwap = () => {
+    const preImage = randomBytes(32);
+    const pairId = `${boltzPairsMap(sendCurrency)}/${boltzPairsMap(
+      receiveCurrency
+    )}`;
+    const params = {
+      type: 'reverseSubmarine',
+      pairId: pairId === 'BTC/LTC' ? 'LTC/BTC' : pairId,
+      orderSide: pairId === 'BTC/LTC' ? 'buy' : 'sell',
+      claimPublicKey: keys.publicKey || '',
+      preimageHash: getHexString(crypto.sha256(preImage)),
+      invoiceAmount: new BigNumber(sendAmount).multipliedBy(10 ** 8).toNumber(),
+    };
+
+    const claimDetails: ClaimDetails = {
+      preImage: preImage,
+      address: address,
+      instantSwap: instant,
+      privateKey: keys.privateKey || '',
+    };
+
+    const errorMessage = 'Something went wrong. Please try again.';
+    setLoading(true);
+    fetch(BOLTZ_CREATE_SWAP_API_URL(apiEndpoint), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+      body: JSON.stringify(params),
+    })
+      .then(async response => {
+        const data: BoltzSwapResponse = await response.json();
+        setLoading(false);
+
+        if (response.status === 201) {
+          setError('');
+          proceedToNext(data, claimDetails);
+          return;
+        }
+        const message = data.error || errorMessage;
+        setError(message);
+      })
+      .catch(() => {
+        setError(errorMessage);
+        setLoading(false);
+      });
+  };
+
+  const addressInvalid = !!address && !isAddressValid(address, network);
+
+  return (
+    <BoltzSwapStep
+      title={
+        <>
+          Paste a {receiveCurrency} address you'd like to receive the funds on
+        </>
+      }
+      content={
+        <Grid item container justify="center">
+          <TextField
+            multiline
+            fullWidth
+            variant="outlined"
+            aria-label={'receive-address'}
+            rows={3}
+            placeholder={placeholder}
+            value={address}
+            onChange={e => {
+              setAddrerss(e.target.value);
+              setError('');
+            }}
+            InputProps={{
+              className: classes.input,
+            }}
+            error={addressInvalid}
+            helperText={addressInvalid && 'Invalid address'}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={instant}
+                onChange={() => setInstant(oldValue => !oldValue)}
+                name="instantSwap"
+                color="primary"
+              />
+            }
+            className={classes.instant}
+            label={
+              <>
+                Swap instantly
+                <Tooltip title="Enabling swap instantly means you agree to accept a 0-conf transaction from Boltz, which results in an instant swap.">
+                  <img
+                    className={classes.instantHint}
+                    src={svgIcons.questionIcon}
+                    alt="hint"
+                  />
+                </Tooltip>
+              </>
+            }
+          />
+        </Grid>
+      }
+      errorMessage={error}
+      mainButtonText="Next"
+      mainButtonVisible
+      onMainButtonClick={createSwap}
+      mainButtonDisabled={!address || !isAddressValid(address, network)}
+      mainButtonLoading={loading}
+    />
+  );
+};
+
+export default BoltzReverseDestination;

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSend/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSend/index.tsx
@@ -1,0 +1,174 @@
+import {
+  createStyles,
+  Grid,
+  Link,
+  makeStyles,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import { ReactElement, useEffect, useMemo, useState } from 'react';
+import {
+  BoltzSwapResponse,
+  StatusResponse,
+  SwapUpdateEvent,
+} from '../../../../constants/boltzSwap';
+import { useAppSelector } from '../../../../store/hooks';
+import { selectSendAsset } from '../../../../store/swaps-slice';
+import svgIcons from '../../../../utils/svgIcons';
+import BoltzSwapStep from '../BoltzSwapStep';
+import Button from '../../../Button';
+import DrawQrCode from '../../../DrawQrCode';
+import { useBlockExplorers } from '../../../../context/NetworkContext';
+import { boltzPairsMap } from '../../../../constants/boltzRates';
+import { timeUntilExpiry } from '../../../../utils/invoiceDecoder';
+import { getETALabelWithSeconds } from '../../../../services/refund/timestamp';
+
+type BoltzReverseSendProps = {
+  swapDetails?: BoltzSwapResponse;
+  swapStatus?: StatusResponse;
+};
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    qrCodeContainer: {
+      marginTop: '1rem',
+    },
+    input: {
+      borderRadius: 0,
+    },
+    titleContainer: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    titleIcon: {
+      height: '1.5rem',
+      marginLeft: '0.5rem',
+    },
+    buttonsContainer: {
+      marginTop: '1rem',
+    },
+    link: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+    linkIcon: {
+      height: '1rem',
+      marginLeft: '0.25rem',
+    },
+    expireContainer: {
+      marginBottom: '1rem',
+    },
+  })
+);
+
+const BoltzReverseSend = (props: BoltzReverseSendProps): ReactElement => {
+  const classes = useStyles();
+  const explorers = useBlockExplorers();
+  const { swapDetails, swapStatus } = props;
+  const sendCurrency = useAppSelector(selectSendAsset);
+  const [etaTimeDiffLabel, setEtaTimeDiffLabel] = useState('');
+  const [etaLeft, setETALeft] = useState(timeUntilExpiry(swapDetails?.invoice));
+
+  const explorer = useMemo(() => explorers.get(boltzPairsMap(sendCurrency)), [
+    sendCurrency,
+    explorers,
+  ]);
+
+  const blockExplorerLink = `${explorer!.address}${swapDetails?.lockupAddress}`;
+
+  const mainButtonText =
+    !!swapStatus && swapStatus.status === SwapUpdateEvent.TransactionMempool
+      ? 'Waiting for one confirmation'
+      : 'Waiting for transaction';
+
+  useEffect(() => {
+    setEtaTimeDiffLabel(getETALabelWithSeconds(etaLeft).label);
+
+    if (etaLeft) {
+      setTimeout(() => {
+        setETALeft(etaLeft - 1);
+      }, 1000);
+    }
+  }, [etaLeft]);
+
+  const eta = etaLeft ? `Expires in ${etaTimeDiffLabel}` : 'Expired!';
+
+  return (
+    <BoltzSwapStep
+      title={
+        <span className={classes.titleContainer}>
+          Pay this {sendCurrency} invoice
+          <Tooltip title="A lightning invoice is how you receive payments on the lightning network. Please use a lightning wallet to pay the invoice.">
+            <img
+              className={classes.titleIcon}
+              src={svgIcons.questionIcon}
+              alt="hint"
+            />
+          </Tooltip>
+        </span>
+      }
+      content={
+        <>
+          <Typography variant="body1" className={classes.expireContainer}>
+            {eta}
+          </Typography>
+          <TextField
+            fullWidth
+            variant="outlined"
+            multiline
+            disabled
+            value={swapDetails!.invoice}
+            InputProps={{
+              className: classes.input,
+            }}
+          />
+          <Grid
+            item
+            container
+            justify="space-between"
+            className={classes.buttonsContainer}
+          >
+            <Link
+              href={blockExplorerLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={classes.link}
+            >
+              Check the lockup
+              <Tooltip title="Check the address to which Boltz will lockup coins after the invoice is paid.">
+                <img
+                  className={classes.linkIcon}
+                  src={svgIcons.questionIcon}
+                  alt="hint"
+                />
+              </Tooltip>
+            </Link>
+            <Button
+              variant="contained"
+              onClick={() =>
+                navigator.clipboard?.writeText(swapDetails!.invoice!)
+              }
+            >
+              Copy Invoice
+            </Button>
+          </Grid>
+          <Grid
+            item
+            container
+            justify="center"
+            className={classes.qrCodeContainer}
+          >
+            <DrawQrCode size={200} link={swapDetails!.invoice} />
+          </Grid>
+        </>
+      }
+      mainButtonVisible
+      mainButtonDisabled
+      mainButtonText={mainButtonText}
+    />
+  );
+};
+
+export default BoltzReverseSend;

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSend/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSend/index.tsx
@@ -71,10 +71,10 @@ const BoltzReverseSend = (props: BoltzReverseSendProps): ReactElement => {
   const [etaTimeDiffLabel, setEtaTimeDiffLabel] = useState('');
   const [etaLeft, setETALeft] = useState(timeUntilExpiry(swapDetails?.invoice));
 
-  const explorer = useMemo(() => explorers.get(boltzPairsMap(sendCurrency)), [
-    sendCurrency,
-    explorers,
-  ]);
+  const explorer = useMemo(
+    () => explorers.get(boltzPairsMap(sendCurrency)),
+    [sendCurrency, explorers]
+  );
 
   const blockExplorerLink = `${explorer!.address}${swapDetails?.lockupAddress}`;
 

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSwap/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSwap/index.tsx
@@ -1,0 +1,110 @@
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import {
+  BoltzSwapResponse,
+  ClaimDetails,
+  StatusResponse,
+  SwapUpdateEvent,
+} from '../../../../constants/boltzSwap';
+import {
+  addReverseSwapDetailsToLocalStorage,
+  claimSwap,
+} from '../../../../utils/boltzReverseSwap';
+import { useBoltzConfiguration } from '../../../../context/NetworkContext';
+import { startListening } from '../../../../utils/boltzSwapStatus';
+import BoltzReverseDestination from './../../components/BoltzReverseDestination';
+import BoltzReverseSend from './../../components/BoltzReverseSend';
+import BoltzReverseSwapResult from './../../components/BoltzReverseSwapResult';
+import { useAppSelector } from '../../../../store/hooks';
+import { selectReceiveAsset } from '../../../../store/swaps-slice';
+import { boltzPairsMap } from '../../../../constants/boltzRates';
+import { removeRefundDetailsFromLocalStorage } from '../../../../utils/boltzRefund';
+
+const BoltzReverseSwap = (): ReactElement => {
+  const receiveCurrency = useAppSelector(selectReceiveAsset);
+  const [activeStep, setActiveStep] = useState(0);
+  const [claimTransactionId, setClaimTransactionId] = useState('');
+  const [swapDetails, setSwapDetails] = useState<BoltzSwapResponse | undefined>(
+    undefined
+  );
+  const [swapStatus, setSwapStatus] = useState<StatusResponse | undefined>(
+    undefined
+  );
+  const [error, setError] = useState('');
+  const {
+    apiEndpoint,
+    bitcoinConstants,
+    litecoinConstants,
+  } = useBoltzConfiguration();
+
+  const network = useMemo(
+    () =>
+      boltzPairsMap(receiveCurrency) === 'BTC'
+        ? bitcoinConstants
+        : litecoinConstants,
+    [bitcoinConstants, litecoinConstants, receiveCurrency]
+  );
+
+  const proceedToNext = useCallback(
+    () => setActiveStep(oldValue => oldValue + 1),
+    [setActiveStep]
+  );
+
+  const destinationComplete = useMemo(
+    () => (swapDetails: BoltzSwapResponse, claimDetails: ClaimDetails) => {
+      addReverseSwapDetailsToLocalStorage({
+        ...claimDetails,
+        swapId: swapDetails.id,
+        redeemScript: swapDetails.redeemScript!,
+      });
+      setSwapDetails(swapDetails);
+      proceedToNext();
+      startListening(swapDetails.id, apiEndpoint, (data, stream) => {
+        setSwapStatus(data);
+        if (
+          (claimDetails.instantSwap &&
+            SwapUpdateEvent.TransactionMempool === data.status) ||
+          SwapUpdateEvent.TransactionConfirmed === data.status
+        ) {
+          claimSwap(
+            claimDetails,
+            data,
+            swapDetails,
+            receiveCurrency,
+            network,
+            apiEndpoint,
+            transaction => setClaimTransactionId(transaction.getId())
+          ).subscribe({
+            next: () => {},
+            error: err => {
+              console.log(err);
+              stream.close();
+              setError('Failed to claim the funds.');
+              proceedToNext();
+            },
+            complete: () => {
+              stream.close();
+              proceedToNext();
+              removeRefundDetailsFromLocalStorage(swapDetails.id);
+            },
+          });
+        } else if (data.failureReason) {
+          stream.close();
+        }
+      });
+    },
+    [proceedToNext, apiEndpoint, network, receiveCurrency]
+  );
+
+  const steps = [
+    <BoltzReverseDestination proceedToNext={destinationComplete} />,
+    <BoltzReverseSend swapDetails={swapDetails} swapStatus={swapStatus} />,
+    <BoltzReverseSwapResult
+      errorMessage={error || swapStatus?.failureReason}
+      transactionId={claimTransactionId}
+    />,
+  ];
+
+  return steps[activeStep];
+};
+
+export default BoltzReverseSwap;

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSwap/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSwap/index.tsx
@@ -23,18 +23,13 @@ const BoltzReverseSwap = (): ReactElement => {
   const receiveCurrency = useAppSelector(selectReceiveAsset);
   const [activeStep, setActiveStep] = useState(0);
   const [claimTransactionId, setClaimTransactionId] = useState('');
-  const [swapDetails, setSwapDetails] = useState<BoltzSwapResponse | undefined>(
-    undefined
-  );
-  const [swapStatus, setSwapStatus] = useState<StatusResponse | undefined>(
-    undefined
-  );
+  const [swapDetails, setSwapDetails] =
+    useState<BoltzSwapResponse | undefined>(undefined);
+  const [swapStatus, setSwapStatus] =
+    useState<StatusResponse | undefined>(undefined);
   const [error, setError] = useState('');
-  const {
-    apiEndpoint,
-    bitcoinConstants,
-    litecoinConstants,
-  } = useBoltzConfiguration();
+  const { apiEndpoint, bitcoinConstants, litecoinConstants } =
+    useBoltzConfiguration();
 
   const network = useMemo(
     () =>

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSwapResult/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSwapResult/index.tsx
@@ -1,0 +1,55 @@
+import { Link } from '@material-ui/core';
+import { ReactElement, useMemo } from 'react';
+import { boltzPairsMap } from '../../../../constants/boltzRates';
+import { SwapStep } from '../../../../constants/swap';
+import { useBlockExplorers } from '../../../../context/NetworkContext';
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { selectSendAsset, setSwapStep } from '../../../../store/swaps-slice';
+import BoltzSwapResult from '../BoltzSwapResult';
+import BoltzSwapStep from '../BoltzSwapStep';
+
+type BoltzReverseSwapResultProps = {
+  errorMessage?: string;
+  transactionId?: string;
+};
+
+const BoltzReverseSwapResult = (
+  props: BoltzReverseSwapResultProps
+): ReactElement => {
+  const { errorMessage, transactionId } = props;
+  const dispatch = useAppDispatch();
+  const explorers = useBlockExplorers();
+  const sendCurrency = useAppSelector(selectSendAsset);
+
+  const explorer = useMemo(() => explorers.get(boltzPairsMap(sendCurrency)), [
+    sendCurrency,
+    explorers,
+  ]);
+
+  const blockExplorerLink = `${explorer!.transaction}${transactionId}`;
+
+  return (
+    <BoltzSwapStep
+      title=""
+      content={
+        <>
+          <BoltzSwapResult errorMessage={errorMessage} />
+          {!errorMessage && (
+            <Link
+              href={blockExplorerLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              See on block explorer
+            </Link>
+          )}
+        </>
+      }
+      mainButtonVisible={!errorMessage}
+      mainButtonText={'Swap again'}
+      onMainButtonClick={() => dispatch(setSwapStep(SwapStep.CHOOSE_PAIR))}
+    />
+  );
+};
+
+export default BoltzReverseSwapResult;

--- a/src/components/BoltzSwapFlow/components/BoltzReverseSwapResult/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzReverseSwapResult/index.tsx
@@ -21,10 +21,10 @@ const BoltzReverseSwapResult = (
   const explorers = useBlockExplorers();
   const sendCurrency = useAppSelector(selectSendAsset);
 
-  const explorer = useMemo(() => explorers.get(boltzPairsMap(sendCurrency)), [
-    sendCurrency,
-    explorers,
-  ]);
+  const explorer = useMemo(
+    () => explorers.get(boltzPairsMap(sendCurrency)),
+    [sendCurrency, explorers]
+  );
 
   const blockExplorerLink = `${explorer!.transaction}${transactionId}`;
 

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineDestination/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineDestination/index.tsx
@@ -34,7 +34,7 @@ import Button from '../../../Button';
 import DownloadRefundFile from '../../../DownloadRefundFile';
 import QrCodeReader from '../../../QrCodeReader';
 
-type BoltzDestinationProps = {
+type BoltzSubmarineDestinationProps = {
   proceedToNext: (swapDetails: BoltzSwapResponse) => void;
 };
 
@@ -67,7 +67,9 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const BoltzDestination = (props: BoltzDestinationProps): ReactElement => {
+const BoltzSubmarineDestination = (
+  props: BoltzSubmarineDestinationProps
+): ReactElement => {
   const { proceedToNext } = props;
   const classes = useStyles();
   const receiveAmount = useAppSelector(selectReceiveAmount);
@@ -107,12 +109,13 @@ const BoltzDestination = (props: BoltzDestinationProps): ReactElement => {
   }, [sendCurrency, receiveCurrency, bitcoinConstants, litecoinConstants]);
 
   const createSwap = () => {
+    const pairId = `${boltzPairsMap(sendCurrency)}/${boltzPairsMap(
+      receiveCurrency
+    )}`;
     const params = {
       type: 'submarine',
-      pairId: `${boltzPairsMap(sendCurrency)}/${boltzPairsMap(
-        receiveCurrency
-      )}`,
-      orderSide: 'sell',
+      pairId: pairId === 'BTC/LTC' ? 'LTC/BTC' : pairId,
+      orderSide: pairId === 'BTC/LTC' ? 'buy' : 'sell',
       invoice: invoice,
       refundPublicKey: keys.publicKey,
       channel: {
@@ -255,4 +258,4 @@ const BoltzDestination = (props: BoltzDestinationProps): ReactElement => {
   );
 };
 
-export default BoltzDestination;
+export default BoltzSubmarineDestination;

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineSend/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineSend/index.tsx
@@ -20,7 +20,7 @@ import BoltzSwapStep from '../BoltzSwapStep';
 import Button from '../../../Button';
 import DrawQrCode from '../../../DrawQrCode';
 
-type BoltzSendProps = {
+type BoltzSubmarineSendProps = {
   swapDetails: BoltzSwapResponse;
   swapStatus?: StatusResponse;
   proceedToNext: () => void;
@@ -37,7 +37,7 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const BoltzSend = (props: BoltzSendProps): ReactElement => {
+const BoltzSubmarineSend = (props: BoltzSubmarineSendProps): ReactElement => {
   const classes = useStyles();
   const { swapDetails, swapStatus, proceedToNext } = props;
   const sendCurrency = useAppSelector(selectSendAsset);
@@ -108,4 +108,4 @@ const BoltzSend = (props: BoltzSendProps): ReactElement => {
   );
 };
 
-export default BoltzSend;
+export default BoltzSubmarineSend;

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineStatus/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineStatus/index.tsx
@@ -14,9 +14,9 @@ import {
   SwapUpdateEvent,
 } from '../../../../constants/boltzSwap';
 import { swapError } from '../../../../utils/boltzSwapStatus';
-import BoltzSwapResult from '../BoltzSwapResult';
+import BoltzSubmarineSwapResult from '../BoltzSubmarineSwapResult';
 
-type BoltzStatusProps = {
+type BoltzSubmarineStatusProps = {
   swapStatus: StatusResponse;
   showRefundButton?: boolean;
   swapId?: string;
@@ -37,7 +37,9 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const BoltzStatus = (props: BoltzStatusProps): ReactElement => {
+const BoltzSubmarineStatus = (
+  props: BoltzSubmarineStatusProps
+): ReactElement => {
   const classes = useStyles();
   const { swapId, swapStatus, showRefundButton, onActiveStepChange } = props;
   const [activeStep, setActiveStep] = useState(0);
@@ -58,7 +60,7 @@ const BoltzStatus = (props: BoltzStatusProps): ReactElement => {
     <>
       {swapError(swapStatus) ||
       swapStatus.status === SwapUpdateEvent.TransactionClaimed ? (
-        <BoltzSwapResult
+        <BoltzSubmarineSwapResult
           swapStatus={swapStatus}
           swapId={swapId}
           showRefundButton={showRefundButton}
@@ -83,4 +85,4 @@ const BoltzStatus = (props: BoltzStatusProps): ReactElement => {
   );
 };
 
-export default BoltzStatus;
+export default BoltzSubmarineStatus;

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineSwap/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineSwap/index.tsx
@@ -13,12 +13,10 @@ import BoltzSubmarineSwapStatus from './../../components/BoltzSubmarineSwapStatu
 
 const BoltzSubmarineSwap = (): ReactElement => {
   const [activeStep, setActiveStep] = useState(0);
-  const [swapDetails, setSwapDetails] = useState<BoltzSwapResponse | undefined>(
-    undefined
-  );
-  const [swapStatus, setSwapStatus] = useState<StatusResponse | undefined>(
-    undefined
-  );
+  const [swapDetails, setSwapDetails] =
+    useState<BoltzSwapResponse | undefined>(undefined);
+  const [swapStatus, setSwapStatus] =
+    useState<StatusResponse | undefined>(undefined);
   const { apiEndpoint } = useBoltzConfiguration();
 
   const proceedToNext = useCallback(

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineSwap/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineSwap/index.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import {
+  BoltzSwapResponse,
+  StatusResponse,
+  SwapUpdateEvent,
+} from '../../../../constants/boltzSwap';
+import { useBoltzConfiguration } from '../../../../context/NetworkContext';
+import { removeRefundDetailsFromLocalStorage } from '../../../../utils/boltzRefund';
+import { isFinal, startListening } from '../../../../utils/boltzSwapStatus';
+import BoltzSubmarineDestination from '../BoltzSubmarineDestination';
+import BoltzSubmarineSend from '../BoltzSubmarineSend';
+import BoltzSubmarineSwapStatus from './../../components/BoltzSubmarineSwapStatus';
+
+const BoltzSubmarineSwap = (): ReactElement => {
+  const [activeStep, setActiveStep] = useState(0);
+  const [swapDetails, setSwapDetails] = useState<BoltzSwapResponse | undefined>(
+    undefined
+  );
+  const [swapStatus, setSwapStatus] = useState<StatusResponse | undefined>(
+    undefined
+  );
+  const { apiEndpoint } = useBoltzConfiguration();
+
+  const proceedToNext = useCallback(
+    () => setActiveStep(oldValue => oldValue + 1),
+    [setActiveStep]
+  );
+
+  const destinationComplete = useMemo(
+    () => (swapDetails: BoltzSwapResponse) => {
+      setSwapDetails(swapDetails);
+      proceedToNext();
+      startListening(swapDetails.id, apiEndpoint, (data, stream) => {
+        setSwapStatus(data);
+        if (isFinal(data)) {
+          stream.close();
+          if (SwapUpdateEvent.TransactionClaimed === data.status) {
+            removeRefundDetailsFromLocalStorage(swapDetails.id);
+          }
+        }
+      });
+    },
+    [proceedToNext, apiEndpoint]
+  );
+
+  const steps = [
+    <BoltzSubmarineDestination proceedToNext={destinationComplete} />,
+    <BoltzSubmarineSend
+      swapDetails={swapDetails!}
+      swapStatus={swapStatus}
+      proceedToNext={proceedToNext}
+    />,
+    <BoltzSubmarineSwapStatus
+      swapStatus={swapStatus!}
+      swapId={swapDetails?.id}
+    />,
+  ];
+
+  return steps[activeStep];
+};
+
+export default BoltzSubmarineSwap;

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineSwapResult/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineSwapResult/index.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { StatusResponse } from '../../../../constants/boltzSwap';
+import { swapError } from '../../../../utils/boltzSwapStatus';
+import BoltzSwapResult from './../BoltzSwapResult';
+
+type BoltzSubmarineSwapResultProps = {
+  swapStatus: StatusResponse;
+  swapId?: string;
+  showRefundButton?: boolean;
+};
+
+const BoltzSubmarineSwapResult = (
+  props: BoltzSubmarineSwapResultProps
+): ReactElement => {
+  const { swapStatus, swapId, showRefundButton } = props;
+
+  return (
+    <BoltzSwapResult
+      errorMessage={swapError(swapStatus)}
+      swapId={swapId}
+      showRefundButton={showRefundButton}
+    />
+  );
+};
+
+export default BoltzSubmarineSwapResult;

--- a/src/components/BoltzSwapFlow/components/BoltzSubmarineSwapStatus/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSubmarineSwapStatus/index.tsx
@@ -4,15 +4,17 @@ import { SwapStep } from '../../../../constants/swap';
 import { useAppDispatch } from '../../../../store/hooks';
 import { setSwapStep } from '../../../../store/swaps-slice';
 import { swapError } from '../../../../utils/boltzSwapStatus';
-import BoltzStatus from '../BoltzStatus';
+import BoltzSubmarineStatus from '../BoltzSubmarineStatus';
 import BoltzSwapStep from '../BoltzSwapStep';
 
-type BoltzSwapStatusProps = {
+type BoltzSubmarineSwapStatusProps = {
   swapStatus: StatusResponse;
   swapId?: string;
 };
 
-const BoltzSwapStatus = (props: BoltzSwapStatusProps): ReactElement => {
+const BoltzSubmarineSwapStatus = (
+  props: BoltzSubmarineSwapStatusProps
+): ReactElement => {
   const { swapStatus, swapId } = props;
   const [activeStep, setActiveStep] = useState<number | undefined>(undefined);
   const dispatch = useAppDispatch();
@@ -24,7 +26,7 @@ const BoltzSwapStatus = (props: BoltzSwapStatusProps): ReactElement => {
     <BoltzSwapStep
       title="Swap status"
       content={
-        <BoltzStatus
+        <BoltzSubmarineStatus
           swapStatus={swapStatus}
           swapId={swapId}
           showRefundButton
@@ -38,4 +40,4 @@ const BoltzSwapStatus = (props: BoltzSwapStatusProps): ReactElement => {
   );
 };
 
-export default BoltzSwapStatus;
+export default BoltzSubmarineSwapStatus;

--- a/src/components/BoltzSwapFlow/components/BoltzSwapResult/index.tsx
+++ b/src/components/BoltzSwapFlow/components/BoltzSwapResult/index.tsx
@@ -1,14 +1,12 @@
 import { createStyles, Grid, makeStyles, Typography } from '@material-ui/core';
 import React, { ReactElement } from 'react';
 import { useHistory } from 'react-router';
-import { StatusResponse } from '../../../../constants/boltzSwap';
-import { swapError } from '../../../../utils/boltzSwapStatus';
 import svgIcons from '../../../../utils/svgIcons';
 import { Path } from '../../../App/path';
 import Button from '../../../Button';
 
 type BoltzSwapResultProps = {
-  swapStatus: StatusResponse;
+  errorMessage?: string;
   swapId?: string;
   showRefundButton?: boolean;
 };
@@ -27,7 +25,7 @@ const useStyles = makeStyles(() =>
 const BoltzSwapResult = (props: BoltzSwapResultProps): ReactElement => {
   const classes = useStyles();
   const history = useHistory();
-  const { swapStatus, swapId, showRefundButton } = props;
+  const { errorMessage, swapId, showRefundButton } = props;
 
   return (
     <Grid
@@ -38,16 +36,16 @@ const BoltzSwapResult = (props: BoltzSwapResultProps): ReactElement => {
       direction="column"
     >
       <Grid item className={classes.imageContainer}>
-        {swapError(swapStatus) ? (
+        {errorMessage ? (
           <img src={svgIcons.snap} alt="aw, snap!" />
         ) : (
           <img src={svgIcons.greenTick} alt="success!" />
         )}
       </Grid>
       <Typography align="center">
-        {swapError(swapStatus) || 'Swap successfully completed!'}
+        {errorMessage || 'Swap successfully completed!'}
       </Typography>
-      {showRefundButton && !!swapError(swapStatus) && (
+      {showRefundButton && !!errorMessage && (
         <Button
           variant="outlined"
           size="large"

--- a/src/constants/boltzSwap.ts
+++ b/src/constants/boltzSwap.ts
@@ -8,6 +8,8 @@ export type BoltzSwapResponse = {
   expectedAmount?: number;
   bip21?: string;
   redeemScript?: string;
+  invoice?: string;
+  lockupAddress?: string;
   error?: string;
 };
 
@@ -23,6 +25,7 @@ export type RefundDetails = {
 export type StatusResponse = {
   status: SwapUpdateEvent;
   failureReason: string;
+  transaction?: LockupTransaction;
 };
 
 export type StatusStep = {
@@ -44,6 +47,18 @@ export type RefundTransaction = {
 };
 
 export type FeeResponse = { [key: string]: number };
+
+export type ClaimDetails = {
+  preImage: Buffer;
+  address: string;
+  instantSwap: boolean;
+  privateKey: string;
+};
+
+export type ReverseSwapDetails = ClaimDetails & {
+  swapId: string;
+  redeemScript: string;
+};
 
 export enum SwapUpdateEvent {
   InvoicePaid = 'invoice.paid',
@@ -92,3 +107,9 @@ export const swapSteps: StatusStep[] = [
     textComplete: 'Transaction complete',
   },
 ];
+
+type LockupTransaction = {
+  id: string;
+  hex: string;
+  eta: number;
+};

--- a/src/context/NetworkContext.tsx
+++ b/src/context/NetworkContext.tsx
@@ -60,10 +60,10 @@ const useNetwork = (): NetworkContextData => {
   return React.useContext(NetworkContext);
 };
 
-const useBlockExplorers = (): Map<CurrencyID, BlockExplorerConfiguration> => {
+const useBlockExplorers = (): Map<string, BlockExplorerConfiguration> => {
   const { network } = React.useContext(NetworkContext);
 
-  const explorers = new Map<CurrencyID, BlockExplorerConfiguration>();
+  const explorers = new Map<string, BlockExplorerConfiguration>();
 
   for (const currency of Object.keys(CurrencyID)) {
     const blockExplorer: BlockExplorerConfiguration = {
@@ -77,7 +77,7 @@ const useBlockExplorers = (): Map<CurrencyID, BlockExplorerConfiguration> => {
       blockExplorer.address !== undefined &&
       blockExplorer.transaction !== undefined
     ) {
-      explorers.set(currency as CurrencyID, blockExplorer);
+      explorers.set(currency, blockExplorer);
     }
   }
 

--- a/src/utils/boltzRefund.ts
+++ b/src/utils/boltzRefund.ts
@@ -121,7 +121,9 @@ export const startRefund = (
   );
 };
 
-const getFeeEstimation = (apiEndpoint: string): Observable<FeeResponse> => {
+export const getFeeEstimation = (
+  apiEndpoint: string
+): Observable<FeeResponse> => {
   return from(fetch(BOLTZ_GET_FEE_ESTIMATION_API_URL(apiEndpoint))).pipe(
     mergeMap((resp: Response) =>
       from(resp.json()).pipe(
@@ -131,7 +133,7 @@ const getFeeEstimation = (apiEndpoint: string): Observable<FeeResponse> => {
   );
 };
 
-const getHexBuffer = (input: string): Buffer => {
+export const getHexBuffer = (input: string): Buffer => {
   return Buffer.from(input, 'hex');
 };
 
@@ -176,7 +178,7 @@ const createRefundTransaction = (
   });
 };
 
-const broadcastRefund = (
+export const broadcastRefund = (
   currency: CurrencyID,
   transactionHex: string,
   apiEndpoint: string

--- a/src/utils/boltzReverseSwap.ts
+++ b/src/utils/boltzReverseSwap.ts
@@ -21,9 +21,10 @@ export const addReverseSwapDetailsToLocalStorage = (
   setBoltzReverseSwapsToLocalStorage(boltzSwaps);
 };
 
-export const getBoltzReverseSwapsFromLocalStorage = (): ReverseSwapDetails[] => {
-  return JSON.parse(localStorage.getItem('boltzReverseSwaps') || '[]');
-};
+export const getBoltzReverseSwapsFromLocalStorage =
+  (): ReverseSwapDetails[] => {
+    return JSON.parse(localStorage.getItem('boltzReverseSwaps') || '[]');
+  };
 
 export const setBoltzReverseSwapsToLocalStorage = (
   swaps: ReverseSwapDetails[]

--- a/src/utils/boltzReverseSwap.ts
+++ b/src/utils/boltzReverseSwap.ts
@@ -1,0 +1,90 @@
+import {
+  BoltzSwapResponse,
+  ClaimDetails,
+  FeeResponse,
+  ReverseSwapDetails,
+  StatusResponse,
+} from '../constants/boltzSwap';
+import CurrencyID from '../constants/currency';
+import { broadcastRefund, getFeeEstimation, getHexBuffer } from './boltzRefund';
+import { boltzPairsMap } from '../constants/boltzRates';
+import { address, ECPair, Network, Transaction } from 'bitcoinjs-lib';
+import { constructClaimTransaction, detectSwap } from 'boltz-core';
+import { Observable, of } from 'rxjs';
+import { mergeMap, tap } from 'rxjs/operators';
+
+export const addReverseSwapDetailsToLocalStorage = (
+  details: ReverseSwapDetails
+): void => {
+  const boltzSwaps = getBoltzReverseSwapsFromLocalStorage();
+  boltzSwaps.push(details);
+  setBoltzReverseSwapsToLocalStorage(boltzSwaps);
+};
+
+export const getBoltzReverseSwapsFromLocalStorage = (): ReverseSwapDetails[] => {
+  return JSON.parse(localStorage.getItem('boltzReverseSwaps') || '[]');
+};
+
+export const setBoltzReverseSwapsToLocalStorage = (
+  swaps: ReverseSwapDetails[]
+): void => {
+  localStorage.setItem('boltzReverseSwaps', JSON.stringify(swaps));
+};
+
+export const claimSwap = (
+  claimDetails: ClaimDetails,
+  status: StatusResponse,
+  swapResponse: BoltzSwapResponse,
+  receiveCurrency: CurrencyID,
+  network: Network,
+  apiEndpoint: string,
+  onClaimTransaction: (transaction: Transaction) => void
+): Observable<void> => {
+  return getFeeEstimation(apiEndpoint).pipe(
+    mergeMap(resp =>
+      of(
+        getClaimTransaction(
+          boltzPairsMap(receiveCurrency),
+          claimDetails,
+          status,
+          swapResponse,
+          network,
+          resp
+        )
+      )
+    ),
+    tap(onClaimTransaction),
+    mergeMap(claimTransaction =>
+      broadcastRefund(receiveCurrency, claimTransaction.toHex(), apiEndpoint)
+    )
+  );
+};
+
+const getClaimTransaction = (
+  onchainCurrency: string,
+  claimDetails: ClaimDetails,
+  statusResponse: StatusResponse,
+  swapResponse: BoltzSwapResponse,
+  network: Network,
+  feeEstimation: FeeResponse
+): Transaction => {
+  const redeemScript = getHexBuffer(swapResponse.redeemScript!);
+  const lockupTransaction = Transaction.fromHex(
+    statusResponse.transaction!.hex
+  );
+
+  return constructClaimTransaction(
+    [
+      {
+        ...detectSwap(redeemScript, lockupTransaction)!,
+        redeemScript,
+        txHash: lockupTransaction.getHash(),
+        preimage: claimDetails.preImage,
+        keys: ECPair.fromPrivateKey(getHexBuffer(claimDetails.privateKey)),
+      },
+    ],
+    address.toOutputScript(claimDetails.address, network),
+    feeEstimation[onchainCurrency],
+    false
+  );
+};


### PR DESCRIPTION
Although the details for claiming the swap are stored in local storage, the functionality of restoring this state when navigating back to opendex.app, and a swap is still in progress, is not implemented. Should be in line with other swap providers, if swap state will be recovered for those as well. Goes same for normal btc submarine swaps.